### PR TITLE
build our own goboring/golang from alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,50 @@
-ARG GO_IMAGE=goboring/golang:1.13.15b4
+ARG GOLANG_VERSION=1.13.15
+FROM library/golang:${GOLANG_VERSION}-alpine AS goboring
+ARG GOBORING_BUILD=4
+RUN apk --no-cache add \
+    bash \
+    g++
+ADD https://go-boringcrypto.storage.googleapis.com/go${GOLANG_VERSION}b${GOBORING_BUILD}.src.tar.gz /usr/local/boring.tgz
+WORKDIR /usr/local/boring
+RUN tar xzf ../boring.tgz
+WORKDIR /usr/local/boring/go/src
+RUN ./make.bash
+RUN rm -rf \
+    /usr/local/go/pkg/*/cmd \
+    /usr/local/go/pkg/bootstrap \
+    /usr/local/go/pkg/obj \
+    /usr/local/go/pkg/tool/*/api \
+    /usr/local/go/pkg/tool/*/go_bootstrap \
+    /usr/local/go/src/cmd/dist/dist
 
-FROM ${GO_IMAGE}
+FROM library/golang:${GOLANG_VERSION}-alpine AS trivy
 ARG TRIVY_VERSION=0.11.0
-ENV LC_ALL C
-ENV DEBIAN_FRONTEND noninteractive
-RUN apt update                                      && \
-    apt upgrade -y                                  && \
-    apt install -y                                     \
-        ca-certificates git bash rsync make wget curl  \
-        software-properties-common apt-utils jq rpm && \ 
-    apt-get --assume-yes clean
-
-RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add && \
-    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian buster stable"
-RUN apt update                 && \
-    apt upgrade -y             && \
-    apt-cache policy docker-ce && \
-    apt install -y docker-ce
-
-RUN if [ "$(go env GOARCH)" = "arm64" ]; then \
-        wget https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-ARM64.tar.gz && \
-        tar -zxvf trivy_${TRIVY_VERSION}_Linux-ARM64.tar.gz                                                && \
-        mv trivy /usr/local/bin;                                                                              \
-    else                                                                                                      \
-        wget https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz && \
-        tar -zxvf trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz                                                && \
-        mv trivy /usr/local/bin;                                                                              \
+RUN set -ex; \
+    if [ "$(go env GOARCH)" = "arm64" ]; then \
+        wget -q "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-ARM64.tar.gz"; \
+        tar -xzf trivy_${TRIVY_VERSION}_Linux-ARM64.tar.gz --include trivy -C /usr/local/bin; \
+        mv trivy /usr/local/bin;                             \
+    else                                                     \
+        wget -q "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"; \
+        tar -xzf trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz; \
+        mv trivy /usr/local/bin;                             \
     fi
-
 RUN trivy --download-db-only
+
+FROM library/golang:${GOLANG_VERSION}-alpine
+RUN apk --no-cache add \
+    bash \
+    coreutils \
+    curl \
+    docker \
+    g++ \
+    git \
+    make \
+    mercurial \
+    rsync \
+    subversion \
+    wget
+RUN rm -fr /usr/local/go/*
+COPY --from=goboring /usr/local/boring/go/ /usr/local/go/
+COPY --from=trivy /usr/local/bin/ /usr/local/bin/
+RUN go version

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,17 @@ else
 	ARCH=$(UNAME_M)
 endif
 
-.PHONY: all
-all:
-	docker build --build-arg TAG=$(TAG) -t rancher/hardened-build-base:$(TAG)-$(ARCH) .
+TAG 			?= v1.13.15b4
+GOLANG_VERSION 	?= $(shell echo $(TAG) | sed -e "s/v\(.*\)b.*/\1/g")
+GOBORING_BUILD	?= $(shell echo $(TAG) | sed -e "s/v.*b//g")
+
+.PHONY: image-build
+image-build:
+	docker build \
+		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
+		--build-arg GOBORING_BUILD=$(GOBORING_BUILD) \
+		--tag rancher/hardened-build-base:$(TAG)-$(ARCH) \
+		.
 
 .PHONY: image-push
 image-push:


### PR DESCRIPTION
The goboring/golang images on dockerhub are based on Debian Buster. Such
aren't suitable for statically linking some of our upstream dependencies
on RKE2 (e.g. containerd, kubernetes, runc). Moving to an Alpine base as
is done here will have us linking statically against musl-c which will
avoid linker warnings such as the following (treated as an error):
```
/usr/local/go/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/usr/bin/ld: /tmp/go-link-679091343/000010.o: in function `bio_ip_and_port_to_socket_and_addr': /boringssl/crypto/bio/socket_helper.c:53: warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking

```

Part of rancher/rke2#335
