### PR TITLE
move trivy out of /usr/local/bin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN set -ex; \
         mv trivy /usr/local/bin;                             \
     else                                                     \
         wget -q "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"; \
-        tar -xzf trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz; \
+        tar -xzf trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz;  \
         mv trivy /usr/local/bin;                             \
     fi
 RUN trivy --download-db-only
@@ -46,5 +46,5 @@ RUN apk --no-cache add \
     wget
 RUN rm -fr /usr/local/go/*
 COPY --from=goboring /usr/local/boring/go/ /usr/local/go/
-COPY --from=trivy /usr/local/bin/ /usr/local/bin/
-RUN go version
+COPY --from=trivy /usr/local/bin/ /usr/bin/
+RUN set -x && go version && trivy --version

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ else
 	ARCH=$(UNAME_M)
 endif
 
+ORG				?= rancher
 TAG 			?= v1.13.15b4
 GOLANG_VERSION 	?= $(shell echo $(TAG) | sed -e "s/v\(.*\)b.*/\1/g")
 GOBORING_BUILD	?= $(shell echo $(TAG) | sed -e "s/v.*b//g")
@@ -15,14 +16,18 @@ image-build:
 	docker build \
 		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
 		--build-arg GOBORING_BUILD=$(GOBORING_BUILD) \
-		--tag rancher/hardened-build-base:$(TAG)-$(ARCH) \
+		--tag $(ORG)/hardened-build-base:$(TAG) \
+		--tag $(ORG)/hardened-build-base:$(TAG)-$(ARCH) \
 		.
 
 .PHONY: image-push
 image-push:
-	docker push rancher/hardened-build-base:$(TAG)-$(ARCH)
+	docker push $(ORG)/hardened-build-base:$(TAG)-$(ARCH)
 
 .PHONY: image-manifest
 image-manifest:
-	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create rancher/hardened-build-base:$(TAG) rancher/hardened-build-base:$(TAG)-$(ARCH)
-	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push rancher/hardened-build-base:$(TAG)
+	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create --amend \
+		$(ORG)/hardened-build-base:$(TAG) \
+		$(ORG)/hardened-build-base:$(TAG)-$(ARCH)
+	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push \
+		$(ORG)/hardened-build-base:$(TAG)


### PR DESCRIPTION
The trivy executable was getting picked up in COPY --from in
multi-stage builds downstream.
