### PR TITLE
introduce reusable scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN apk --no-cache add \
     curl \
     docker \
     g++ \
+    gcc \
     git \
     make \
     mercurial \
@@ -47,4 +48,5 @@ RUN apk --no-cache add \
 RUN rm -fr /usr/local/go/*
 COPY --from=goboring /usr/local/boring/go/ /usr/local/go/
 COPY --from=trivy /usr/local/bin/ /usr/bin/
+COPY scripts/ /usr/local/bin/
 RUN set -x && go version && trivy --version

--- a/scripts/go-assert-boring.sh
+++ b/scripts/go-assert-boring.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+if [ -z "$*" ]; then
+    echo "usage: $0 file1 \[file2 ... fileN\]"
+fi
+for exe in "${@}"; do
+    if [ ! -x "${exe}" ]; then
+        echo "$exe: file not found" >&2
+        exit 1
+    fi
+    if [ $(go tool nm ${exe} | grep Cfunc__goboringcrypto | wc -l) -eq 0 ]; then
+        echo "${exe}: missing goboring linkage" >&2
+        exit 1
+    fi
+done

--- a/scripts/go-assert-static.sh
+++ b/scripts/go-assert-static.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+if [ -z "$*" ]; then
+    echo "usage: $0 file1 \[file2 ... fileN\]"
+fi
+for exe in "${@}"; do
+    if [ ! -x "${exe}" ]; then
+        echo "$exe: file not found" >&2
+        exit 1
+    fi
+    if ! file "${exe}" | grep -E '.*ELF.*executable, .*, statically linked,.*'; then
+        file "${exe}" >&2
+        echo "${exe}: not a statically linked executable" >&2
+        exit 1
+    fi
+done

--- a/scripts/go-build-static.sh
+++ b/scripts/go-build-static.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -x
+exec go build -ldflags "-extldflags \"-static -Wl,--fatal-warnings\" ${GO_LDFLAGS}" "${@}"


### PR DESCRIPTION
- go-build-static.sh will incorporate $GO_LDFLAGS into the built-in -ldflags,
  all other arguments as pass-through to go build
- go-assert-static attempts to assert, via file, that the argument(s) are
  properly linked static executables
- go-assert-boring attempts to assert, via go tool nm, that the argument(s)
  are linked against goboring
