### PR TITLE
Drop mercurial

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,6 @@ RUN apk --no-cache add \
     gcc \
     git \
     make \
-    mercurial \
     rsync \
     subversion \
     wget


### PR DESCRIPTION
It looks like this was only used in buildroot, which appears
to have stalled in development.