### PR TITLE
Update documentation regarding Go+BoringCrypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
 # rancher/hardened-build-base
 
+This repository holds the Dockerfiles and builds scripts for [rancher/hardened-build-base](https://hub.docker.com/r/rancher/hardened-build-base) Docker images. The x86_64 image contains a FIPS compatible Go compiler ([Go+BoringCrypto](https://github.com/golang/go/tree/dev.boringcrypto/misc/boring)), used for [compiling rke2 components](https://docs.rke2.io/security/fips_support/#fips-support-in-cluster-components).
+
+Supported architectures are x86_64/amd64, arm64, and s390x.
+
 ## Build
 
-```sh
-TAG=v1.14.2 make
+```shell
+TAG=v1.13.15b4 make
 ```
+
+### Versioning
+
+The images built within this repository use the same versioning format as [GoBoring](https://github.com/golang/go/tree/dev.boringcrypto/misc/boring#version-strings), using the `<Go version>b<BoringCrypto version>` pattern.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # rancher/hardened-build-base
 
-This repository holds the Dockerfiles and builds scripts for [rancher/hardened-build-base](https://hub.docker.com/r/rancher/hardened-build-base) Docker images. The x86_64 image contains a FIPS compatible Go compiler ([Go+BoringCrypto](https://github.com/golang/go/tree/dev.boringcrypto/misc/boring)), used for [compiling rke2 components](https://docs.rke2.io/security/fips_support/#fips-support-in-cluster-components).
+This repository holds the Dockerfiles and builds scripts for [rancher/hardened-build-base](https://hub.docker.com/r/rancher/hardened-build-base) Docker images. The `x86_64` image contains a Go compiler with FIPS 140-2 compliant crypto module, [GoBoring](https://github.com/golang/go/tree/dev.boringcrypto/misc/boring), used for [compiling rke2 components](https://docs.rke2.io/security/fips_support/#fips-support-in-cluster-components).
 
-Supported architectures are x86_64/amd64, arm64, and s390x.
+Supported architectures
+
+- [x86_64/amd64](Dockerfile.amd64)
+- [s390x](Dockerfile.s390x)
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Supported architectures
 
 ## Build
 
-```shell
+```sh
 TAG=v1.13.15b4 make
 ```
 


### PR DESCRIPTION
Problem: As new contributor is easy to overlook that rke2 componentes
are compiled using a FIPS 140-2 compatible Go compiler.

Solution: Update README file pointing out the Go+BoringCrypto usage.