### PR TITLE
Adding support for ARM64 image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -50,6 +50,59 @@ volumes:
   temp: {}
 ---
 kind: pipeline
+name: linux-arm64
+platform:
+  os: linux
+  arch: amd64
+
+node:
+  arch: arm64
+
+steps:
+- name: build
+  image: docker:18.06-dind
+  volumes:
+  - name: dockersock
+    path: /var/run
+  commands:
+  - sleep 20
+  - apk add make
+  - TAG=${DRONE_TAG} make
+  when:
+    event:
+    - tag
+
+- name: push
+  image: docker:18.06-dind
+  volumes:
+  - name: dockersock
+    path: /var/run
+  commands:
+  - apk add make
+  - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+  - TAG=${DRONE_TAG} make image-push
+  environment:
+    DOCKER_USERNAME:
+      from_secret: docker_username
+    DOCKER_PASSWORD:
+      from_secret: docker_password
+  when:
+    event:
+    - tag
+
+services:
+- name: docker
+  image: docker:18.06-dind
+  privileged: true
+  volumes:
+  - name: dockersock
+    path: /var/run
+
+volumes:
+- name: dockersock
+  temp: {}
+---
+kind: pipeline
 name: linux-s390x
 platform:
   os: linux

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -14,10 +14,10 @@ COPY scripts/ /usr/local/boring/go/bin/
 FROM library/golang:${GOLANG_VERSION}-alpine3.15 AS trivy
 ARG TRIVY_VERSION=0.18.3
 RUN set -ex; \
-    wget -q "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"; \
-    tar -xzf trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz;  \
+    wget -q "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-ARM64.tar.gz"; \
+    tar -xzf trivy_${TRIVY_VERSION}_Linux-ARM64.tar.gz;  \
     mv trivy /usr/local/bin;                             \
-    rm trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz;
+    rm trivy_${TRIVY_VERSION}_Linux-ARM64.tar.gz;
 
 FROM library/golang:${GOLANG_VERSION}-alpine3.15
 RUN apk --no-cache add \


### PR DESCRIPTION
This PR is to address https://github.com/rancher/image-build-base/issues/18 which includes the following changes.

- Removed the ARM64 check in the AMD64 Dockerfile as it wasn't working and we're breaking out Dockerfile for ARM64 always so there is no need for this.
- Created a Dockerfile called `Dockerfile.aarch64` which is a clone of `Dockerfile.arm64` but with a different trivy release.

I run a test building the current image on a Raspberry Pi 4 Model B Rev 1.4 without issue. (See output below)

```
root@a1pirke2workp08:~/go/src/github.com/mattmattox/image-build-base# TAG=v1.18.1b7 make
docker build \
	--build-arg GOLANG_VERSION=1.18.1 \
	--build-arg GOBORING_BUILD=7 \
	--tag rancher/hardened-build-base:v1.18.1b7 \
	--tag rancher/hardened-build-base:v1.18.1b7-aarch64 \
	. \
	-f Dockerfile.aarch64
Sending build context to Docker daemon  144.4kB
Step 1/19 : ARG GOLANG_VERSION=1.17.5
Step 2/19 : FROM library/golang:${GOLANG_VERSION}-alpine3.15 AS goboring
 ---> fa7d7e2a19b3
Step 3/19 : ARG GOBORING_BUILD=7
 ---> Running in 53349c458505
Removing intermediate container 53349c458505
 ---> 3a690d50131a
Step 4/19 : RUN apk --no-cache add     bash     g++
 ---> Running in 4507b05f49fc
fetch https://dl-cdn.alpinelinux.org/alpine/v3.15/main/aarch64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.15/community/aarch64/APKINDEX.tar.gz
(1/18) Installing ncurses-terminfo-base (6.3_p20211120-r1)
(2/18) Installing ncurses-libs (6.3_p20211120-r1)
(3/18) Installing readline (8.1.1-r0)
(4/18) Installing bash (5.1.16-r0)
Executing bash-5.1.16-r0.post-install
(5/18) Installing libgcc (10.3.1_git20211027-r0)
(6/18) Installing libstdc++ (10.3.1_git20211027-r0)
(7/18) Installing binutils (2.37-r3)
(8/18) Installing libgomp (10.3.1_git20211027-r0)
(9/18) Installing libatomic (10.3.1_git20211027-r0)
(10/18) Installing libgphobos (10.3.1_git20211027-r0)
(11/18) Installing gmp (6.2.1-r1)
(12/18) Installing isl22 (0.22-r0)
(13/18) Installing mpfr4 (4.1.0-r0)
(14/18) Installing mpc1 (1.2.1-r0)
(15/18) Installing gcc (10.3.1_git20211027-r0)
(16/18) Installing musl-dev (1.2.2-r7)
(17/18) Installing libc-dev (0.7.2-r3)
(18/18) Installing g++ (10.3.1_git20211027-r0)
Executing busybox-1.34.1-r5.trigger
OK: 191 MiB in 33 packages
Removing intermediate container 4507b05f49fc
 ---> e944c67a6031
Step 5/19 : ADD https://go-boringcrypto.storage.googleapis.com/go${GOLANG_VERSION}b${GOBORING_BUILD}.src.tar.gz /usr/local/boring.tgz
Downloading  25.66MB/25.66MB

 ---> b4146a4143df
Step 6/19 : WORKDIR /usr/local/boring
 ---> Running in 17a0596874ba
Removing intermediate container 17a0596874ba
 ---> c9102ebc012a
Step 7/19 : RUN tar xzf ../boring.tgz
 ---> Running in 885d3ca7465a
Removing intermediate container 885d3ca7465a
 ---> fccebd14f6a6
Step 8/19 : WORKDIR /usr/local/boring/go/src
 ---> Running in e4429aac9bd8
Removing intermediate container e4429aac9bd8
 ---> 66ec896ecf11
Step 9/19 : RUN ./make.bash
 ---> Running in 99d4114f2b89
Building Go cmd/dist using /usr/local/go. (go1.18.1 linux/arm64)
Building Go toolchain1 using /usr/local/go.
Building Go bootstrap cmd/go (go_bootstrap) using Go toolchain1.
Building Go toolchain2 using go_bootstrap and Go toolchain1.
Building Go toolchain3 using go_bootstrap and Go toolchain2.
Building packages and commands for linux/arm64.
---
Installed Go for linux/arm64 in /usr/local/boring/go
Installed commands in /usr/local/boring/go/bin
Removing intermediate container 99d4114f2b89
 ---> d373b785c823
Step 10/19 : COPY scripts/ /usr/local/boring/go/bin/
 ---> d570a838307b
Step 11/19 : FROM library/golang:${GOLANG_VERSION}-alpine3.15 AS trivy
 ---> fa7d7e2a19b3
Step 12/19 : ARG TRIVY_VERSION=0.18.3
 ---> Running in ace075a5b946
Removing intermediate container ace075a5b946
 ---> 1c2a5facb345
Step 13/19 : RUN set -ex;     wget -q "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-ARM64.tar.gz";     tar -xzf trivy_${TRIVY_VERSION}_Linux-ARM64.tar.gz;      mv trivy /usr/local/bin;                                 rm trivy_${TRIVY_VERSION}_Linux-ARM64.tar.gz;
 ---> Running in c5e31f84d4a6
+ wget -q https://github.com/aquasecurity/trivy/releases/download/v0.18.3/trivy_0.18.3_Linux-ARM64.tar.gz
+ tar -xzf trivy_0.18.3_Linux-ARM64.tar.gz
+ mv trivy /usr/local/bin
+ rm trivy_0.18.3_Linux-ARM64.tar.gz
Removing intermediate container c5e31f84d4a6
 ---> 83cd5a94864d
Step 14/19 : FROM library/golang:${GOLANG_VERSION}-alpine3.15
 ---> fa7d7e2a19b3
Step 15/19 : RUN apk --no-cache add     bash     coreutils     curl     docker     file     g++     gcc     git     make     mercurial     rsync     subversion     wget
 ---> Using cache
 ---> 4b8f50ccdc6c
Step 16/19 : RUN rm -fr /usr/local/go/*
 ---> Using cache
 ---> 1857179ab96b
Step 17/19 : COPY --from=goboring /usr/local/boring/go/ /usr/local/go/
 ---> 778c1c0c0e6a
Step 18/19 : COPY --from=trivy /usr/local/bin/ /usr/bin/
 ---> 41d1a03cffc6
Step 19/19 : RUN set -x  && chmod -v +x /usr/local/go/bin/go-*.sh  && go version  && trivy --download-db-only --quiet
 ---> Running in 1110060d9c96
+ chmod -v +x /usr/local/go/bin/go-assert-boring.sh /usr/local/go/bin/go-assert-static.sh /usr/local/go/bin/go-build-static.sh
mode of '/usr/local/go/bin/go-assert-boring.sh' retained as 0775 (rwxrwxr-x)
mode of '/usr/local/go/bin/go-assert-static.sh' retained as 0775 (rwxrwxr-x)
mode of '/usr/local/go/bin/go-build-static.sh' retained as 0775 (rwxrwxr-x)
+ go version
go version go1.18.1b7 linux/arm64
+ trivy --download-db-only --quiet
Removing intermediate container 1110060d9c96
 ---> 7e396ac76d60
Successfully built 7e396ac76d60
Successfully tagged rancher/hardened-build-base:v1.18.1b7
Successfully tagged rancher/hardened-build-base:v1.18.1b7-aarch64
root@a1pirke2workp08:~/go/src/github.com/mattmattox/image-build-base#
```