### PR TITLE
Updates to v1.19

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,15 +1,4 @@
-ARG GOLANG_VERSION=1.17.5
-FROM library/golang:${GOLANG_VERSION}-alpine3.15 AS goboring
-ARG GOBORING_BUILD=7
-RUN apk --no-cache add \
-    bash \
-    g++
-ADD https://go-boringcrypto.storage.googleapis.com/go${GOLANG_VERSION}b${GOBORING_BUILD}.src.tar.gz /usr/local/boring.tgz
-WORKDIR /usr/local/boring
-RUN tar xzf ../boring.tgz
-WORKDIR /usr/local/boring/go/src
-RUN ./make.bash
-COPY scripts/ /usr/local/boring/go/bin/
+ARG GOLANG_VERSION=1.19.0
 
 FROM library/golang:${GOLANG_VERSION}-alpine3.15 AS trivy
 ARG TRIVY_VERSION=0.18.3
@@ -39,8 +28,7 @@ RUN apk --no-cache add \
     rsync \
     subversion \
     wget
-RUN rm -fr /usr/local/go/*
-COPY --from=goboring /usr/local/boring/go/ /usr/local/go/
+COPY scripts/ /usr/local/go/bin/
 COPY --from=trivy /usr/local/bin/ /usr/bin/
 RUN set -x \
  && chmod -v +x /usr/local/go/bin/go-*.sh \

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -1,4 +1,4 @@
-ARG GOLANG_VERSION=1.17.5
+ARG GOLANG_VERSION=1.19.0-alpine3.15
 FROM library/golang:${GOLANG_VERSION}-alpine3.15
 RUN apk --no-cache add \
     bash \

--- a/Makefile
+++ b/Makefile
@@ -7,15 +7,13 @@ else
 endif
 
 ORG				?= rancher
-TAG 			?= v1.13.15b4
+TAG 			?= v1.19.0
 GOLANG_VERSION 	?= $(shell echo $(TAG) | sed -e "s/v\(.*\)b.*/\1/g")
-GOBORING_BUILD	?= $(shell echo $(TAG) | sed -e "s/v.*b//g")
 
 .PHONY: image-build
 image-build:
 	docker build \
 		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
-		--build-arg GOBORING_BUILD=$(GOBORING_BUILD) \
 		--tag $(ORG)/hardened-build-base:$(TAG) \
 		--tag $(ORG)/hardened-build-base:$(TAG)-$(ARCH) \
 		. \

--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ TAG=v1.13.15b4 make
 
 ### Versioning
 
-The images built within this repository use the same versioning format as [GoBoring](https://github.com/golang/go/tree/dev.boringcrypto/misc/boring#version-strings), using the `<Go version>b<BoringCrypto version>` pattern.
+Starting from v1.19.0 dev.boringcrypto branch has been moved to the main branch behind GOEXPERIMENT variable, so the image-build-base will be adding `GOEXPERIMENT=boringcrypto` to `scripts/go-build-static.sh` script, however the build will still retain the same versionining using the `<Go version>b<BoringCrypto version>` pattern.

--- a/scripts/go-build-static.sh
+++ b/scripts/go-build-static.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 export CGO_ENABLED=${CGO_ENABLED:-1}
+export GOEXPERIMENT=boringcrypto
+
 if [ "${CGO_ENABLED}" != "1" ]; then
   echo "CGO_ENABLED=${CGO_ENABLED}, should be set to 1 for static goboring compilation" >&2
   exit 1


### PR DESCRIPTION
Updates include:

- Removal of goboring branch
- Adding `GOEXPERIMENT=boringcrypto` to the go-build-static.sh script