### PR TITLE
Fix CI failure caused by non-existant alpine version

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,6 +1,7 @@
 ARG GOLANG_VERSION=1.19.0
+ARG ALPINE_VERSION=3.16
 
-FROM library/golang:${GOLANG_VERSION}-alpine3.15 AS trivy
+FROM library/golang:${GOLANG_VERSION}-alpine${ALPINE_VERSION} AS trivy
 ARG TRIVY_VERSION=0.18.3
 RUN set -ex; \
     if [ "$(go env GOARCH)" = "arm64" ]; then \
@@ -13,7 +14,7 @@ RUN set -ex; \
         mv trivy /usr/local/bin;                             \
     fi
 
-FROM library/golang:${GOLANG_VERSION}-alpine3.15
+FROM library/golang:${GOLANG_VERSION}-alpine${ALPINE_VERSION}
 RUN apk --no-cache add \
     bash \
     coreutils \

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -1,5 +1,7 @@
 ARG GOLANG_VERSION=1.19.0-alpine3.15
-FROM library/golang:${GOLANG_VERSION}-alpine3.15
+ARG ALPINE_VERSION=3.16
+
+FROM library/golang:${GOLANG_VERSION}-alpine${ALPINE_VERSION}
 RUN apk --no-cache add \
     bash \
     coreutils \


### PR DESCRIPTION
Alpine 3.15 for Go 1.19.4 does not exist. This PR ensures that the alpine versions within the dockerfile are aligned and bumps to the closest existing version. Here is the failed run for context:
https://drone-publish.rancher.io/rancher/image-build-base/145