### PR TITLE
Add reviewers to dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "rancher/k3s"
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "rancher/k3s"
 


### PR DESCRIPTION
This adds rancher/k3s to the PRs that dependabot generates.
This contributes to https://github.com/rancher/rke2/issues/4143.
I tested this by running [the dependabot cli](https://github.com/dependabot/cli) locally:
<details>
  <summary>Test Scenario</summary>
```
dependabot update docker rancher/image-build-base -o dependabot_test

cat dependabot_test 

input:
    job:
        package-manager: docker
        allowed-updates:
            - update-type: all
        source:
            provider: github
            repo: rancher/image-build-base
            directory: /
            commit: 74e40bedfb4c53b26ae59dedbab5b5e2bab41fc8
        credentials-metadata:
            - host: github.com
              type: git_source
    credentials:
        - host: github.com
          password: $LOCAL_GITHUB_ACCESS_TOKEN
          type: git_source
          username: x-access-token
output:
    - type: update_dependency_list
      expect:
        data:
            dependencies: []
            dependency_files:
                - /Dockerfile.amd64
                - /Dockerfile.s390x
    - type: mark_as_processed
      expect:
        data:
            base-commit-sha: 74e40bedfb4c53b26ae59dedbab5b5e2bab41fc8
```

</details>