### PR TITLE
Add Updatecli workflow to update Trivy

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -2,7 +2,7 @@ ARG GOLANG_VERSION=1.19.0
 ARG ALPINE_VERSION=3.16
 
 FROM library/golang:${GOLANG_VERSION}-alpine${ALPINE_VERSION} AS trivy
-ARG TRIVY_VERSION=0.18.3
+ARG TRIVY_VERSION=0.40.0
 RUN set -ex; \
     wget -q "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"; \
     tar -xzf trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz; \
@@ -28,4 +28,4 @@ COPY --from=trivy /usr/local/bin/ /usr/bin/
 RUN set -x && \
     chmod -v +x /usr/local/go/bin/go-*.sh && \
     go version && \
-    trivy --download-db-only --quiet
+    trivy image --download-db-only --quiet

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -2,7 +2,7 @@ ARG GOLANG_VERSION=1.19.0
 ARG ALPINE_VERSION=3.16
 
 FROM library/golang:${GOLANG_VERSION}-alpine${ALPINE_VERSION} AS trivy
-ARG TRIVY_VERSION=0.18.3
+ARG TRIVY_VERSION=0.40.0
 RUN set -ex; \
     wget -q "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-ARM64.tar.gz"; \
     tar -xzf trivy_${TRIVY_VERSION}_Linux-ARM64.tar.gz; \
@@ -31,4 +31,4 @@ COPY --from=trivy /usr/local/bin/ /usr/bin/
 RUN set -x && \
     chmod -v +x /usr/local/go/bin/go-*.sh && \
     go version && \
-    trivy --download-db-only --quiet
+    trivy image --download-db-only --quiet

--- a/updatecli/updatecli.d/trivy.yml
+++ b/updatecli/updatecli.d/trivy.yml
@@ -1,0 +1,65 @@
+---
+name: "Bump Trivy version"
+scms:
+  image-build-base:
+    kind: "github"
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      username: "{{ .github.username }}"
+      token: "{{ requiredEnv .github.token }}"
+      owner: "rancher"
+      repository: "image-build-base"
+      branch: "master"
+      commitmessage:
+        title: "Bump Trivy version"
+
+sources:
+  trivy-release:
+    name: "Get Trivy latest release"
+    kind: "githubrelease"
+    spec:
+      owner: "aquasecurity"
+      repository: "trivy"
+      token: "{{ requiredEnv .github.token }}"
+      versionfilter:
+        kind: "latest"
+    transformers:
+      - trimprefix: "v"
+
+conditions:
+  trivy-version:
+    name: "Check Trivy version in Dockerfile.amd64"
+    kind: "file"
+    scmid: "image-build-base"
+    disablesourceinput: true
+    spec:
+      files:
+        - "Dockerfile.amd64"
+        - "Dockerfile.arm64"
+      matchpattern: 'TRIVY_VERSION={{ source `trivy-release` }}'
+    failwhen: true
+
+targets:
+  trivy-version:
+    name: "Update Trivy version in Dockerfile.amd64"
+    kind: "file"
+    scmid: "image-build-base"
+    disablesourceinput: true
+    spec:
+      files:
+        - "Dockerfile.amd64"
+        - "Dockerfile.arm64"
+      matchpattern: 'TRIVY_VERSION=\d+\.\d+.\d+'
+      replacepattern: 'TRIVY_VERSION={{ source `trivy-release` }}'
+
+actions:
+  github:
+    title: "Bump Trivy version"
+    kind: "github/pullrequest"
+    scmid: "image-build-base"
+    spec:
+      automerge: false
+      draft: false
+      mergemethod: "squash"
+      parent: false


### PR DESCRIPTION
This PR does:

1. Adds an Updatecli workflow to update Trivy. See example PR https://github.com/macedogm/image-build-base/pull/3.
2. Update Trivy to a recent version, but not the latest, so the Updatecli workflow can run afterwards.
3. Update Trivy's `--download-db-only` command, because in recent versions it's now a subcommand of the `image` command.

Notes:

1. This PR is important, because we are using a very old version of Trivy that doesn't scan Go binaries properly (it might miss some CVEs). Addresses https://github.com/rancher/image-build-base/issues/22.
2. RKE2 removed Trivy from it's image - https://github.com/rancher/rke2/pull/4187 - in order to use the Trivy embedded in the base image. However, the `scan` pipeline is now [failing](https://drone-publish.rancher.io/rancher/rke2/2961/1/5), because the scan command in RKE2 [uses](https://github.com/rancher/rke2/blob/9fdfef645be8d23c38504605b262dfedfe49e0dc/scripts/scan-images#L10) the `image` command.
3. After merging this PR, we must bump RKE2's [`hardened-build-base`](https://github.com/rancher/rke2/blob/9fdfef645be8d23c38504605b262dfedfe49e0dc/Dockerfile#L4) version.
4. Do the same bump for all images and hardened image that use this base image and also update the Trivy command in the `scan` make target (see example in [`rancher/image-build-kubernetes`](https://github.com/rancher/image-build-kubernetes/blob/6b5b7ac61f6f653b58bf1eaaa9b8361bc4fb73b5/Makefile#L57)) to use the image command `trivy image --severity...` instead of `trivy --severity...`.