### PR TITLE
Add support for position-independent executables (static-pie)

### DIFF
--- a/scripts/go-assert-static.sh
+++ b/scripts/go-assert-static.sh
@@ -10,7 +10,7 @@ for exe in "${@}"; do
         exit 1
     fi
     
-    if ! file "${exe}" | grep -E '.*ELF.*executable, .*, statically linked,.*'; then
+    if ! file "${exe}" | grep -E '.*ELF.*executable, .*, (statically|static-pie) linked,.*'; then
         file "${exe}" >&2
         echo "${exe}: not a statically linked executable" >&2
         exit 1


### PR DESCRIPTION
runc is now producing static-pie binaries: https://drone-publish.rancher.io/rancher/image-build-runc/59/1/2

This is statically linked, but is rejected by the go-assert-static script.

```
#8 [builder  8/11] RUN go-assert-static.sh runc
#8 sha256:76a40b6ba9b591a4a4cbf5ebf637fa6caea2a78164db0d5979cb0f119c6f987b
#8 0.292 runc: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), static-pie linked, Go BuildID=1CTLEUF3DdkTs6IyBuGO/LcWDI4-YjqoMXdCuiPHV/jDaCbXbhRhpICHNGOytz/zXFXFfs0dX-EJ3lwmbXQ, with debug_info, not stripped
#8 0.292 runc: not a statically linked executable
#8 ERROR: process "/bin/sh -c go-assert-static.sh runc" did not complete successfully: exit code: 1
```

I'm not sure why this just started failing, as they've been doing this for quite a while: https://github.com/opencontainers/runc/pull/3446