### PR TITLE
add release-go github action

### DIFF
--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -1,0 +1,19 @@
+name: Check Go versions and create releases
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 9 * * *'
+jobs:
+  release_go_versions:
+    name: Check Go versions and create releases
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+    - name: setup ecm-distro-tools
+      uses: rancher/ecm-distro-tools
+      with:
+        version: v0.24.0
+    - name: check go versions and release
+        run: rke2_release image-build-base-release

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -2,7 +2,7 @@ name: Check Go versions and create releases
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 9 * * *'
+    - cron: "0 9 * * *"
 jobs:
   release_go_versions:
     name: Check Go versions and create releases
@@ -11,9 +11,9 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - name: setup ecm-distro-tools
-      uses: rancher/ecm-distro-tools
-      with:
-        version: v0.24.0
-    - name: check go versions and release
+      - name: setup ecm-distro-tools
+        uses: rancher/ecm-distro-tools
+        with:
+          version: v0.24.0
+      - name: check go versions and release
         run: rke2_release image-build-base-release

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -3,7 +3,6 @@ on:
   schedule:
     - cron: "0 9 * * *"
   workflow_dispatch:
-
 jobs:
   release_go_versions:
     name: Check Go versions and create releases
@@ -17,4 +16,8 @@ jobs:
         with:
           version: v0.24.1
       - name: check go versions and release
-        run: rke2_release image-build-base-release
+        run: |
+          OS=$(uname -s)
+          ARCH=$(uname -m)
+          [[ $ARCH="x86_64" ]] && ARCH="amd64"
+          rke2_release-${OS,,}-${ARCH} image-build-base-release

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -12,8 +12,8 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: setup ecm-distro-tools
-        uses: rancher/ecm-distro-tools@v0.23.0
+        uses: rancher/ecm-distro-tools@v0.24.1
         with:
-          version: v0.24.0
+          version: v0.24.1
       - name: check go versions and release
         run: rke2_release image-build-base-release

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -12,7 +12,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: setup ecm-distro-tools
-        uses: rancher/ecm-distro-tools
+        uses: rancher/ecm-distro-tools@v0.23.0
         with:
           version: v0.24.0
       - name: check go versions and release

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -1,8 +1,9 @@
 name: Check Go versions and create releases
 on:
-  workflow_dispatch:
   schedule:
     - cron: "0 9 * * *"
+  workflow_dispatch:
+
 jobs:
   release_go_versions:
     name: Check Go versions and create releases


### PR DESCRIPTION
Adds a github action that runs every day to get stable go versions and create releases if they doesn't exist yet.