### PR TITLE
update release-go ecm-distro-tools to v0.27.0

### DIFF
--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -1,7 +1,7 @@
 name: Check Go versions and create releases
 on:
   schedule:
-    - cron: "0 9 * * *"
+    - cron: "0 17 * * *"
   workflow_dispatch:
 jobs:
   release_go_versions:
@@ -12,12 +12,9 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: setup ecm-distro-tools
-        uses: rancher/ecm-distro-tools@v0.24.1
+        uses: rancher/ecm-distro-tools@v0.27.0
         with:
-          version: v0.24.1
+          version: v0.27.0
       - name: check go versions and release
         run: |
-          OS=$(uname -s)
-          ARCH=$(uname -m)
-          [[ $ARCH="x86_64" ]] && ARCH="amd64"
-          rke2_release-${OS,,}-${ARCH} image-build-base-release
+          rke2_release image-build-base-release --alpine-version 3.18


### PR DESCRIPTION
* Changes the cron time from 9:00 to 17:00
* Updates ecm-distro-tools to version v0.27.0 that ensures the docker image exists before creating the release