### PR TITLE
Bump alpine version to 3.19

### DIFF
--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -17,4 +17,4 @@ jobs:
           version: v0.27.0
       - name: check go versions and release
         run: |
-          rke2_release image-build-base-release --alpine-version 3.18
+          rke2_release image-build-base-release --alpine-version 3.19

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,14 @@ ARG GOLANG_VERSION=1.22.4
 
 FROM --platform=$TARGETPLATFORM library/golang:${GOLANG_VERSION}-alpine AS golang
 
-FROM alpine:3.18 as trivy-amd64
+FROM alpine:3.19 as trivy-amd64
 ARG TRIVY_VERSION=0.42.0
 RUN set -ex; \
     wget -q "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"; \
     tar -xzf trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz; \
     mv trivy /usr/local/bin
 
-FROM alpine:3.18 as trivy-arm64
+FROM alpine:3.19 as trivy-arm64
 ARG TRIVY_VERSION=0.42.0
 RUN set -ex; \
     wget -q "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-ARM64.tar.gz"; \
@@ -18,7 +18,7 @@ RUN set -ex; \
 
 FROM trivy-${TARGETARCH} as trivy-base
 
-FROM alpine:3.18
+FROM alpine:3.19
 ENV GOTOOLCHAIN=local
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH


### PR DESCRIPTION
New Go versions don't have alpine 3.18 images and new releases are not being created: https://github.com/rancher/image-build-base/actions/runs/10098452123/job/27925525404