### PR TITLE
Update ecm-distro action and rke2_release command

### DIFF
--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -12,9 +12,9 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: setup ecm-distro-tools
-        uses: rancher/ecm-distro-tools@v0.52.0
+        uses: rancher/ecm-distro-tools@v0.56.0
         with:
-          version: v0.52.0
+          version: v0.56.0
       - name: check go versions and release
         run: |
-          rke2_release image-build-base-release --alpine-version 3.21
+          rke2_release image-build-base-release


### PR DESCRIPTION
Updates `rancher/ecm-distro-tools` action to [v0.56.0](https://github.com/rancher/ecm-distro-tools/releases/tag/v0.56.0)